### PR TITLE
Renaming docs to documents to match API

### DIFF
--- a/relevanceai/api/batch/batch_insert.py
+++ b/relevanceai/api/batch/batch_insert.py
@@ -808,8 +808,10 @@ class BatchInsertClient(Utils, BatchRetrieveClient, APIClient, Chunker):
                 )
             return sample_docs
 
-        self.pull_update_push(dataset_id, update_function, 
-            retrieve_chunk_size=retrieve_chunk_size, 
-            max_workers=max_workers, 
-            show_progress_bar=show_progress_bar
+        self.pull_update_push(
+            dataset_id,
+            update_function,
+            retrieve_chunk_size=retrieve_chunk_size,
+            max_workers=max_workers,
+            show_progress_bar=show_progress_bar,
         )

--- a/relevanceai/datasets.py
+++ b/relevanceai/datasets.py
@@ -63,12 +63,12 @@ class ExampleDatasets:
             project,
             api_key,
         )
-        docs = client.get_documents(
+        documents = client.get_documents(
             db_name,
             number_of_documents=number_of_documents,
             select_fields=select_fields,
         )
-        return docs
+        return documents
 
     @staticmethod
     def _get_online_dataset(
@@ -218,13 +218,13 @@ def get_ecommerce_2_dataset(
     """
     if number_of_documents is None:
         number_of_documents = 1000
-    docs = ExampleDatasets._get_dummy_dataset(
+    documents = ExampleDatasets._get_dummy_dataset(
         "quickstart_data_sample", number_of_documents, select_fields
     )
-    for d in docs:
+    for d in documents:
         if "image_first" in d:
             d["image"] = d.pop("image_first")
-    return docs
+    return documents
 
 
 def get_online_retail_dataset(
@@ -352,11 +352,11 @@ def get_ecommerce_3_dataset(
         df["url"] = df["url"].str.replace("http://", "https://")
     if "_unit_id" in df.columns:
         df["_id"] = df["_unit_id"].astype(str)
-    docs = [
+    documents = [
         {k: v for k, v in doc.items() if not pd.isna(v)}
         for doc in df.to_dict(orient="records")
     ]
-    return docs
+    return documents
 
 
 def get_flipkart_dataset(

--- a/relevanceai/utils.py
+++ b/relevanceai/utils.py
@@ -39,8 +39,8 @@ class Utils(BatchAPIClient, _Base, DocUtils):
         else:
             raise ValueError(f"{label_name} is not in the {dataset_id} schema")
 
-    def _remove_empty_vector_fields(self, docs, vector_field: str) -> List[Dict]:
+    def _remove_empty_vector_fields(self, documents, vector_field: str) -> List[Dict]:
         """
         Remove documents with empty vector fields
         """
-        return [d for d in docs if d.get(vector_field)]
+        return [d for d in documents if d.get(vector_field)]

--- a/relevanceai/utils.py
+++ b/relevanceai/utils.py
@@ -47,4 +47,6 @@ class Utils(APIClient, _Base, DocUtils):
         return [d for d in documents if d.get(vector_field)]
 
     def _convert_id_to_string(self, documents):
-        self.set_field_across_documents("_id", [str(i["_id"]) for i in documents], documents)
+        self.set_field_across_documents(
+            "_id", [str(i["_id"]) for i in documents], documents
+        )

--- a/relevanceai/vector_tools/cluster.py
+++ b/relevanceai/vector_tools/cluster.py
@@ -153,7 +153,9 @@ class CentroidCluster(ClusterBase):
         """Get centers for the centroid-based clusters"""
         raise NotImplementedError
 
-    def get_centroid_documents(self, centroid_vector_field_name="centroid_vector_") -> List:
+    def get_centroid_documents(
+        self, centroid_vector_field_name="centroid_vector_"
+    ) -> List:
         """Get the centroid documents to store.
         if single vector field returns this:
             {

--- a/relevanceai/vector_tools/cluster.py
+++ b/relevanceai/vector_tools/cluster.py
@@ -153,7 +153,7 @@ class CentroidCluster(ClusterBase):
         """Get centers for the centroid-based clusters"""
         raise NotImplementedError
 
-    def get_centroid_docs(self, centroid_vector_field_name="centroid_vector_") -> List:
+    def get_centroid_documents(self, centroid_vector_field_name="centroid_vector_") -> List:
         """Get the centroid documents to store.
         if single vector field returns this:
             {

--- a/relevanceai/vector_tools/cluster.py
+++ b/relevanceai/vector_tools/cluster.py
@@ -99,11 +99,14 @@ class ClusterBase(LoguruLogger, DocUtils):
 
         new_documents = documents.copy()
 
-        self.set_field_across_documents(set_cluster_field, cluster_labels, new_documents)
+        self.set_field_across_documents(
+            set_cluster_field, cluster_labels, new_documents
+        )
 
         if return_only_clusters:
             return [
-                {"_id": d.get("_id"), cluster_field: d.get(cluster_field)} for d in documents
+                {"_id": d.get("_id"), cluster_field: d.get(cluster_field)}
+                for d in documents
             ]
         return documents
 

--- a/relevanceai/vector_tools/cluster_evaluate.py
+++ b/relevanceai/vector_tools/cluster_evaluate.py
@@ -91,7 +91,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
             ground_truth_field=ground_truth_field,
             description_fields=description_fields,
         )
-        self.plot_from_docs(
+        self.plot_from_documents(
             vectors=vectors,
             cluster_labels=cluster_labels,
             ground_truth=ground_truth,
@@ -134,7 +134,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
             cluster_alias=cluster_alias,
             ground_truth_field=ground_truth_field,
         )
-        return self.metrics_from_docs(
+        return self.metrics_from_documents(
             vectors=vectors, cluster_labels=cluster_labels, ground_truth=ground_truth
         )
 
@@ -180,16 +180,16 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
 
         if ground_truth_field:
             if transpose:
-                return self.label_joint_distribution_from_docs(
+                return self.label_joint_distribution_from_documents(
                     cluster_labels, ground_truth
                 )
             else:
-                return self.label_joint_distribution_from_docs(
+                return self.label_joint_distribution_from_documents(
                     ground_truth, cluster_labels
                 )
 
         else:
-            return self.label_distribution_from_docs(cluster_labels)
+            return self.label_distribution_from_documents(cluster_labels)
 
     def _get_cluster_documents(
         self,
@@ -217,7 +217,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         else:
             vector_select_field = []
 
-        docs = self.get_all_documents(
+        documents = self.get_all_documents(
             dataset_id,
             chunk_size=1000,
             select_fields=["_id", cluster_field]
@@ -227,24 +227,24 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         )
 
         # Get cluster labels
-        cluster_labels = self.get_field_across_documents(cluster_field, docs)
+        cluster_labels = self.get_field_across_documents(cluster_field, documents)
 
         # Get vectors
         if get_vectors:
-            vectors = self.get_field_across_documents(vector_field, docs)
+            vectors = self.get_field_across_documents(vector_field, documents)
         else:
             vectors = None
 
         # Get ground truth
         if ground_truth_field:
-            ground_truth = self.get_field_across_documents(ground_truth_field, docs)
+            ground_truth = self.get_field_across_documents(ground_truth_field, documents)
         else:
             ground_truth = None
 
         # Get vector description
         if len(description_fields) > 0:
             vector_description: Optional[Dict] = {
-                field: self.get_field_across_documents(field, docs)
+                field: self.get_field_across_documents(field, documents)
                 for field in description_fields
             }
         else:
@@ -253,7 +253,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         return vectors, cluster_labels, ground_truth, vector_description
 
     @staticmethod
-    def plot_from_docs(
+    def plot_from_documents(
         vectors: list,
         cluster_labels: list,
         ground_truth: list = None,
@@ -345,7 +345,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         return
 
     @staticmethod
-    def metrics_from_docs(vectors, cluster_labels, ground_truth=None):
+    def metrics_from_documents(vectors, cluster_labels, ground_truth=None):
         """
         Determine the performance of clusters through the Silhouette Score, and optionally against ground truth labels through Rand Index, Homogeneity and Completeness
 
@@ -397,7 +397,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         return metrics_list
 
     @staticmethod
-    def label_distribution_from_docs(label):
+    def label_distribution_from_documents(label):
         """
         Determine the distribution of a label
 
@@ -411,7 +411,7 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
         return dict(label_sparsity)
 
     @staticmethod
-    def label_joint_distribution_from_docs(label_1, label_2):
+    def label_joint_distribution_from_documents(label_1, label_2):
         """
         Determine the distribution of a label against another label
 

--- a/relevanceai/vector_tools/cluster_evaluate.py
+++ b/relevanceai/vector_tools/cluster_evaluate.py
@@ -237,7 +237,9 @@ class ClusterEvaluate(BatchAPIClient, _Base, DocUtils):
 
         # Get ground truth
         if ground_truth_field:
-            ground_truth = self.get_field_across_documents(ground_truth_field, documents)
+            ground_truth = self.get_field_across_documents(
+                ground_truth_field, documents
+            )
         else:
             ground_truth = None
 

--- a/relevanceai/vector_tools/nearest_neighbours.py
+++ b/relevanceai/vector_tools/nearest_neighbours.py
@@ -14,7 +14,7 @@ class NearestNeighbours(_Base, DocUtils):
 
     @staticmethod
     def get_nearest_neighbours(
-        docs: list,
+        documents: list,
         vector: list,
         vector_field: str,
         distance_measure_mode: NEAREST_NEIGHBOURS = "cosine",
@@ -24,21 +24,21 @@ class NearestNeighbours(_Base, DocUtils):
         if callable_distance:
             sort_key = [
                 callable_distance(i, vector)
-                for i in doc_utils.get_field_across_documents(vector_field, docs)
+                for i in doc_utils.get_field_across_documents(vector_field, documents)
             ]
             reverse = False
 
         elif distance_measure_mode == "cosine":
             sort_key = [
                 1 - spatial_distance.cosine(i, vector)
-                for i in doc_utils.get_field_across_documents(vector_field, docs)
+                for i in doc_utils.get_field_across_documents(vector_field, documents)
             ]
             reverse = True
 
         elif distance_measure_mode == "l2":
             sort_key = [
                 spatial_distance.euclidean(i, vector)
-                for i in doc_utils.get_field_across_documents(vector_field, docs)
+                for i in doc_utils.get_field_across_documents(vector_field, documents)
             ]
             reverse = False
 
@@ -46,9 +46,9 @@ class NearestNeighbours(_Base, DocUtils):
             raise ValueError("Need valid distance measure mode or callable distance")
 
         doc_utils.set_field_across_documents(
-            "nearest_neighbour_distance", sort_key, docs
+            "nearest_neighbour_distance", sort_key, documents
         )
 
         return sorted(
-            docs, reverse=reverse, key=lambda x: x["nearest_neighbour_distance"]
+            documents, reverse=reverse, key=lambda x: x["nearest_neighbour_distance"]
         )

--- a/relevanceai/vector_tools/plot_text_theme_model.py
+++ b/relevanceai/vector_tools/plot_text_theme_model.py
@@ -295,16 +295,16 @@ class PlotTextThemeModel(BatchAPIClient, BaseTextProcessing, LoguruLogger, DocUt
         run_fit=True,
     ):
         self.logger.info(" * Dimensionality reduction")
-        vector_data = np.array(vector_data)
+        vector_data_array = np.array(vector_data)
         if run_fit:
             self.dr_model = Ivis(
                 embedding_dims=embedding_dims,
                 k=k,
                 n_epochs_without_progress=n_epochs_without_progress,
             )
-            dr_docs = self.dr_model.fit_transform(vector_data)
+            dr_docs = self.dr_model.fit_transform(vector_data_array)
         else:
-            dr_docs = self.dr_model.transform(vector_data)
+            dr_docs = self.dr_model.transform(vector_data_array)
 
         return dr_docs
 

--- a/relevanceai/visualise/dash_components/app.py
+++ b/relevanceai/visualise/dash_components/app.py
@@ -16,7 +16,7 @@ def create_dash_graph(
     plot_data,
     layout,
     show_image,
-    docs,
+    documents,
     vector_label,
     vector_field,
     interactive: bool = True,
@@ -48,7 +48,7 @@ def create_dash_graph(
         )
 
     app.layout = create_layout(app)
-    # display_callbacks(app, show_image, docs, vector_label)
+    # display_callbacks(app, show_image, documents, vector_label)
     if interactive:
-        neighbour_callbacks(app, show_image, docs, vector_label, vector_field)
+        neighbour_callbacks(app, show_image, documents, vector_label, vector_field)
     app.run_server(mode="inline")

--- a/relevanceai/visualise/dash_components/callbacks.py
+++ b/relevanceai/visualise/dash_components/callbacks.py
@@ -16,7 +16,7 @@ doc_utils = DocUtils()
 MAX_SIZE = 200
 
 
-def display_callbacks(app, show_image, docs, vector_label):
+def display_callbacks(app, show_image, documents, vector_label):
 
     if show_image:
 
@@ -30,7 +30,7 @@ def display_callbacks(app, show_image, docs, vector_label):
             except TypeError:
                 return None
 
-            click_doc = [i for i in docs if i["_id"] == click_id][0]
+            click_doc = [i for i in documents if i["_id"] == click_id][0]
             image_url = click_doc[vector_label]
 
             return [
@@ -54,7 +54,7 @@ def display_callbacks(app, show_image, docs, vector_label):
 def neighbour_callbacks(
     app,
     show_image,
-    docs,
+    documents,
     vector_label,
     vector_field,
     distance_measure_mode="cosine",
@@ -66,11 +66,11 @@ def neighbour_callbacks(
         except TypeError:
             return None
 
-        click_doc = [i for i in docs if i["_id"] == click_id][0]
+        click_doc = [i for i in documents if i["_id"] == click_id][0]
 
         click_vec = click_doc[vector_field]
         nearest_neighbors = NearestNeighbours.get_nearest_neighbours(
-            docs, click_vec, vector_field, distance_measure_mode
+            documents, click_vec, vector_field, distance_measure_mode
         )[:n]
         nearest_neighbor_values = doc_utils.get_field_across_documents(
             vector_label, nearest_neighbors

--- a/relevanceai/visualise/projector.py
+++ b/relevanceai/visualise/projector.py
@@ -145,16 +145,16 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
         # Check hover label field
         [self._is_valid_label_name(dataset_id, label) for label in hover_label]
 
-        docs = self.get_documents(
+        documents = self.get_documents(
             dataset_id,
             number_of_documents=number_of_points_to_render,
             batch_size=1000,
             select_fields=["_id", vector_field] + vector_label_field + hover_label,
         )
-        docs = self._remove_empty_vector_fields(docs, vector_field)
+        documents = self._remove_empty_vector_fields(documents, vector_field)
 
-        return self.plot_from_docs(
-            docs,
+        return self.plot_from_documents(
+            documents,
             vector_field=vector_field,
             vector_label=vector_label,
             label_char_length=label_char_length,
@@ -172,9 +172,9 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
             interactive=interactive,
         )
 
-    def plot_from_docs(
+    def plot_from_documents(
         self,
-        docs: List[Dict],
+        documents: List[Dict],
         vector_field: str,
         # Plot rendering args
         vector_label: Union[None, str] = None,
@@ -200,12 +200,12 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
         if show_image is False and vector_label:
             self.set_field_across_documents(
                 vector_label,
-                [i[vector_label][:label_char_length] + "..." for i in docs],
-                docs,
+                [i[vector_label][:label_char_length] + "..." for i in documents],
+                documents,
             )
 
         # Dimension reduce vectors
-        vectors = np.array(self.get_field_across_documents(vector_field, docs))
+        vectors = np.array(self.get_field_across_documents(vector_field, documents))
         vectors_dr = DimReduction.dim_reduce(
             vectors=vectors, dr=dr, dr_args=dr_args, dims=dims
         )
@@ -214,7 +214,7 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
             points["z"] = vectors_dr[:, 2]
 
         embedding_df = pd.DataFrame(points)
-        embedding_df = pd.concat([embedding_df, pd.DataFrame(docs)], axis=1)
+        embedding_df = pd.concat([embedding_df, pd.DataFrame(documents)], axis=1)
 
         # Set hover labels
         if vector_label:
@@ -265,7 +265,7 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
             plot_data=plot_data,
             layout=layout,
             show_image=show_image,
-            docs=docs,
+            documents=documents,
             vector_label=vector_label,
             vector_field=vector_field,
             interactive=interactive,

--- a/relevanceai/visualise/projector.py
+++ b/relevanceai/visualise/projector.py
@@ -245,7 +245,7 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
                 "You are missing Jupyter Dash, please run `pip install jupyter_dash`"
             )
 
-        docs = self._get_plot_docs(
+        documents = self._get_plot_docs(
             dataset_id=dataset_id,
             vector_field=vector_field,
             number_of_points_to_render=number_of_points_to_render,
@@ -254,7 +254,7 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
         )
 
         return self.plot_from_documents(
-            documents,
+            documents=documents,
             vector_field=vector_field,
             vector_label=vector_label,
             label_char_length=label_char_length,
@@ -403,7 +403,7 @@ class Projector(Utils, BatchAPIClient, _Base, DocUtils):
                 plot_data=plot_data,
                 layout=layout,
                 show_image=show_image,
-                docs=docs,
+                documents=documents,
                 vector_label=vector_label,
                 vector_field=vector_field,
                 interactive=interactive,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ requirements = [
     "requests>=2.0.0",
     "numpy>=1.19.0",
     "joblib>=1.0.0",
+    "matplotlib>=3.5.1",
+    "nltk>=3.6.7",
 ]
 
 excel_requirements = requirements + ["openpyxl>=3.0.9", "fsspec>=2021.10.1"]
@@ -47,7 +49,7 @@ vis_requirements = requirements + [
 umap = ["umap-learn>=0.5.2"]
 # ivis_cpu = ["ivis[cpu]>=2.0.6"]
 # ivis_gpu = ["ivis[gpu]>=2.0.6"]
-kmedoids = ["scikit-learn-extra>=0.2.0"]
+# kmedoids = ["scikit-learn-extra>=0.2.0"]
 hdbscan = ["hdbscan>=0.8.27"]
 
 # vis_extras = umap + ivis_cpu + ivis_gpu + kmedoids + hdbscan
@@ -120,7 +122,7 @@ setup(
         "umap": umap,
         # "ivis-cpu": ivis_cpu,
         # "ivis-gpu": ivis_gpu,
-        "kmedoids": kmedoids,
+        # "kmedoids": kmedoids,
         "hdbscan": hdbscan,
     },
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ dev_requirements = [
     "jupyter",
     "sphinx-rtd-theme>=0.5.0",
     "sphinx-autoapi==1.8.4",
-    "sphinx-autodoc-typehints==1.12.0"
+    "sphinx-autodoc-typehints==1.12.0",
 ] + test_requirements
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,8 @@ def test_dataset_id():
 @pytest.fixture(scope="session")
 def test_sample_dataset(test_client, simple_doc, test_dataset_id):
     """Sample dataset to insert and then delete"""
-    simple_docs = simple_doc * 1000
-    response = test_client.insert_documents(test_dataset_id, simple_docs)
+    simple_documents = simple_doc * 1000
+    response = test_client.insert_documents(test_dataset_id, simple_documents)
     yield test_dataset_id
     test_client.datasets.delete(test_dataset_id)
 
@@ -56,8 +56,8 @@ def test_sample_dataset(test_client, simple_doc, test_dataset_id):
 @pytest.fixture(scope="session")
 def test_large_sample_dataset(test_client, simple_doc, test_dataset_id):
     """Sample dataset to insert and then delete"""
-    simple_docs = simple_doc * 1000
-    response = test_client.insert_documents(test_dataset_id, simple_docs)
+    simple_documents = simple_doc * 1000
+    response = test_client.insert_documents(test_dataset_id, simple_documents)
     yield test_dataset_id
     test_client.datasets.delete(test_dataset_id)
 
@@ -68,7 +68,7 @@ def error_doc():
 
 
 @pytest.fixture(scope="session")
-def sample_vector_docs():
+def sample_vector_documents():
     def _sample_vector_doc(doc_id: str):
         return {
             "_id": doc_id,
@@ -88,9 +88,9 @@ def sample_vector_docs():
 
 
 @pytest.fixture(scope="session")
-def test_sample_vector_dataset(test_client, sample_vector_docs, test_dataset_id):
+def test_sample_vector_dataset(test_client, sample_vector_documents, test_dataset_id):
     """Sample vector dataset"""
-    response = test_client.insert_documents(test_dataset_id, sample_vector_docs)
+    response = test_client.insert_documents(test_dataset_id, sample_vector_documents)
     yield test_dataset_id
     test_client.datasets.delete(test_dataset_id)
 

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -9,17 +9,17 @@ def test_cluster_integration(test_client, test_sample_vector_dataset):
     # Retrieve a previous dataset
     VECTOR_FIELD = "sample_1_vector_"
     ALIAS = "kmeans_10"
-    docs = test_client.datasets.documents.list(test_sample_vector_dataset)
+    documents = test_client.datasets.documents.list(test_sample_vector_dataset)
 
-    # check if docs are inserted
-    if len(docs["documents"]) == 0:
-        raise ValueError("Missing docs")
+    # check if documents are inserted
+    if len(documents["documents"]) == 0:
+        raise ValueError("Missing documents")
     cluster = KMeans(k=10)
     # Now when we want to fit the documents
-    docs["documents"] = cluster.fit_documents([VECTOR_FIELD], docs["documents"])
+    documents["documents"] = cluster.fit_documents([VECTOR_FIELD], documents["documents"])
 
     # Centroids
-    cluster_centers = cluster.get_centroid_docs()
+    cluster_centers = cluster.get_centroid_documents()
     test_client.services.cluster.centroids.insert(
         test_sample_vector_dataset,
         vector_fields=[VECTOR_FIELD],

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -16,7 +16,9 @@ def test_cluster_integration(test_client, test_sample_vector_dataset):
         raise ValueError("Missing documents")
     cluster = KMeans(k=10)
     # Now when we want to fit the documents
-    documents["documents"] = cluster.fit_documents([VECTOR_FIELD], documents["documents"])
+    documents["documents"] = cluster.fit_documents(
+        [VECTOR_FIELD], documents["documents"]
+    )
 
     # Centroids
     cluster_centers = cluster.get_centroid_documents()

--- a/tests/integration/test_quickstart.py
+++ b/tests/integration/test_quickstart.py
@@ -4,7 +4,7 @@ import time
 
 
 def test_quickstart(test_client):
-    docs = [
+    documents = [
         {"_id": "1", "example_vector_": [0.1, 0.1, 0.1]},
         {"_id": "2", "example_vector_": [0.2, 0.2, 0.2]},
         {"_id": "3", "example_vector_": [0.3, 0.3, 0.3]},
@@ -12,7 +12,7 @@ def test_quickstart(test_client):
         {"_id": "5", "example_vector_": [0.5, 0.5, 0.5]},
     ]
 
-    test_client.insert_documents(dataset_id="quickstart", docs=docs)
+    test_client.insert_documents(dataset_id="quickstart", documents=documents)
     time.sleep(2)
     results = test_client.services.search.vector(
         dataset_id="quickstart",

--- a/tests/unit/test_batch_insert.py
+++ b/tests/unit/test_batch_insert.py
@@ -10,30 +10,30 @@ class TestInsert:
 
     def test_batch_insert(self, simple_doc, test_dataset_id, test_client):
         """Batch insert"""
-        simple_docs = simple_doc * 100
-        results = test_client.insert_documents(test_dataset_id, simple_docs)
+        simple_documents = simple_doc * 100
+        results = test_client.insert_documents(test_dataset_id, simple_documents)
         assert len(results["failed_documents"]) == 0
 
 
 # Mock a callable For pull update push
-def do_nothing(docs):
-    return docs
+def do_nothing(documents):
+    return documents
 
 
-def cause_error(docs):
-    for d in docs:
+def cause_error(documents):
+    for d in documents:
         d["value"] = np.nan
-    return docs
+    return documents
 
 
-def cause_some_error(docs):
+def cause_some_error(documents):
     MAX_ERRORS = 5
     ERROR_COUNT = 0
-    for d in docs:
+    for d in documents:
         if ERROR_COUNT < MAX_ERRORS:
             d["value"] = np.nan
             ERROR_COUNT += 1
-    return docs
+    return documents
 
 
 class TestPullUpdatePush:
@@ -62,11 +62,11 @@ class TestPullUpdatePush:
     def test_pull_update_push_loaded(self, test_sample_dataset, test_client):
         """Stress testing pull update push."""
 
-        def do_nothing(docs):
-            return docs
+        def do_nothing(documents):
+            return documents
 
         response = test_client.pull_update_push(test_sample_dataset, do_nothing)
-        assert len(response["failed_documents"]) == 0, "Failed to insert docs"
+        assert len(response["failed_documents"]) == 0, "Failed to insert documents"
 
 
 # class TestCleanUp:


### PR DESCRIPTION
Hello, I am renaming docs to documents to match API and vectorhub to standardise the interface here!

Renaming named_args  and reference to `docs` to `documents` 


eg. 
before

```
client.insert_documents(dataset_id=DATASET_ID, docs=dataset_2)
```

to
```
client.insert_documents(dataset_id=DATASET_ID, documents=dataset_2)
```


Charlene