### PR TITLE
add missing requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ dev_requirements = [
     "pylint",
     "jupyter",
     "sphinx-rtd-theme>=0.5.0",
+    "sphinx-autoapi==1.8.4",
 ] + test_requirements
 
 


### PR DESCRIPTION
Adds a missing requirement for documentation. 
Sphinx Auto API is used to help us with documenting the API and having multiple layers in our documentation. 