### PR TITLE
Move to warning and add message mentioning chunksize

### DIFF
--- a/relevanceai/api/batch/batch_insert.py
+++ b/relevanceai/api/batch/batch_insert.py
@@ -716,8 +716,8 @@ class BatchInsertClient(Utils, BatchRetrieveClient, APIClient, Chunker):
                         failed_ids += [i["_id"] for i in chunk["documents"]]
 
                 # Update docs to retry which have failed
-                self.logger.error(
-                    f"Failed to upload {failed_ids}. Retrying with chunksize {chunksize}"
+                self.logger.warning(
+                    f"Failed to upload {failed_ids}. Automatically retrying for you with chunksize {chunksize}"
                 )
                 docs = [i for i in docs if i["_id"] in failed_ids]
 


### PR DESCRIPTION
While this is by nature an error, we are automatically re-trying for them so adjusted to warning so people don't think otherwise. Thoughts on this behavior? Otherwise - can keep as error but with adjusted error message. 