### PR TITLE
Added test_sentence_splitting/test_ops

### DIFF
--- a/tests/unit/test_sentence_splitting/test_ops.py
+++ b/tests/unit/test_sentence_splitting/test_ops.py
@@ -1,0 +1,37 @@
+from relevanceai.dataset import Dataset
+
+from relevanceai import mock_documents
+
+from relevanceai.operations_new.processing.text.sentence_splitting.ops import (
+    SentenceSplitterOps,
+)
+
+
+class TestSentenceSplitterOps:
+    def test_split_text(self):
+        ops = SentenceSplitterOps()
+        text = """Loudermilk and GOP Rep. Rodney Davis, the top Republican on the House Administration Committee,
+        issued a joint statement later Thursday responding to the committee's letter again pushing back on
+        any allegation of "reconnaissance" tours on January 5 and calling for Capitol Police to release
+        the footage."""
+        texts = ops.split_text(
+            text=text,
+            language="en",
+        )
+        for t in texts:
+            assert t in text
+
+    def test_split_text_document(self):
+        ops = SentenceSplitterOps()
+        document = {
+            "status": 0,
+            "params": {
+                "facet_range": "initial_release_date",
+                "facet_limit": "300",
+                "facet_range_gap": "+1YEAR",
+            },
+        }
+        documents = ops.split_text_document(
+            text_field="params.facet_limit", document=document, output_field="output"
+        )
+        assert documents["output"][0] == {"params.facet_limit": "300"}


### PR DESCRIPTION
Added test_split_text, test_split_test_document

```
 tests\unit\test_sentence_splitting\test_ops.py::TestSentenceSplitterOps.test_split_text ✓                                  50% █████     [gw0] PASSED tests/unit/test_sentence_splitting/test_ops.py
 tests\unit\test_sentence_splitting\test_ops.py::TestSentenceSplitterOps.test_split_text_document ✓                        100% ██████████[gw0] PASSED tests/unit/test_sentence_splitting/test_ops.py

----------- coverage: platform win32, python 3.9.5-final-0 -----------
Coverage HTML written to dir htmlcov

FAIL Required test coverage of 70% not reached. Total coverage: 27.75%

Results (18.71s):

       2 passed
```