### PR TITLE
Fix task dopne

### DIFF
--- a/relevanceai/__init__.py
+++ b/relevanceai/__init__.py
@@ -24,7 +24,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-__version__ = "3.2.8"
+__version__ = "3.2.9"
 
 try:
     pypi_data = requests.get("https://pypi.org/pypi/relevanceai/json").json()

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -320,9 +320,6 @@ class PullTransformPush:
         while len(batch) < chunksize:
             try:
                 document = queue.get(timeout=timeout)
-                if document == KILL_SIGNAL:
-                    self.tq.task_done()
-                    self._has_kill_signal = True
                 batch.append(document)
             except:
                 break
@@ -376,6 +373,7 @@ class PullTransformPush:
                 if len(batch) > 0:
                     if batch[-1] == KILL_SIGNAL:
                         HAS_KILL_SIGNAL = True
+                        self.tq.task_done()
 
             if self.func is not None:
                 old_batch = deepcopy(batch)
@@ -502,6 +500,7 @@ class PullTransformPush:
                     if batch[-1] == KILL_SIGNAL:
                         HAS_KILL_SIGNAl = True
                         batch = batch[:-1]
+                        self.pq.task_done()
 
             batch = self.pull_dataset.json_encoder(batch)
             update = PullTransformPush._get_updates(batch)

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -286,7 +286,6 @@ class PullTransformPush:
                 with self.general_lock:
                     self.ndocs = self.pull_count
                 self.tq.put(KILL_SIGNAL)
-                self._has_kill_signal = True
                 break
             after_id = res["after_id"]
 
@@ -373,6 +372,7 @@ class PullTransformPush:
                 if len(batch) > 0:
                     if batch[-1] == KILL_SIGNAL:
                         HAS_KILL_SIGNAL = True
+                        print("Killing transform queue.")
                         self.tq.task_done()
 
             if self.func is not None:
@@ -401,6 +401,7 @@ class PullTransformPush:
 
             # Send kill signal to push queue
             if HAS_KILL_SIGNAL:
+                print("Killing Push queue")
                 self.pq.put(KILL_SIGNAL)
 
             with self.general_lock:

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -44,6 +44,7 @@ class PullTransformPush:
 
     pull_dataset: Dataset
     push_dataset: Dataset
+    _is_task_done: bool = False
 
     def __init__(
         self,
@@ -282,7 +283,9 @@ class PullTransformPush:
             if not documents:
                 with self.general_lock:
                     self.ndocs = self.pull_count
-                self.tq.task_done()
+                if not self._is_task_done:
+                    self.tq.task_done()
+                    self._is_task_done = True
                 break
             after_id = res["after_id"]
 

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -368,8 +368,6 @@ class PullTransformPush:
         # Check for early termination (such as no documents)
         HAS_KILL_SIGNAL: bool = False
         print("Begin transform.")
-        print(self.transform_count)
-        print(self.ndocs)
         while self.transform_count <= self.ndocs and not self.timeout_event.is_set():
             print("Inside transform loop.")
             with self.transform_batch_lock:

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -379,6 +379,7 @@ class PullTransformPush:
                         HAS_KILL_SIGNAL = True
                         print("Killing transform queue.")
                         self.tq.task_done()
+                        batch = batch[:-1]
 
             if self.func is not None:
                 old_batch = deepcopy(batch)

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -46,7 +46,6 @@ class PullTransformPush:
 
     pull_dataset: Dataset
     push_dataset: Dataset
-    _is_task_done: bool = False
     _has_kill_signal: bool = True
 
     def __init__(
@@ -286,10 +285,8 @@ class PullTransformPush:
             if not documents:
                 with self.general_lock:
                     self.ndocs = self.pull_count
-                if not self._is_task_done:
-                    self.tq.put(KILL_SIGNAL)
-                    self._is_task_done = True
-                    self._has_kill_signal = True
+                self.tq.put(KILL_SIGNAL)
+                self._has_kill_signal = True
                 break
             after_id = res["after_id"]
 

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -368,7 +368,9 @@ class PullTransformPush:
         # Check for early termination (such as no documents)
         HAS_KILL_SIGNAL: bool = False
         print("Begin transform.")
-        while self.transform_count < self.ndocs and not self.timeout_event.is_set():
+        print(self.transform_count)
+        print(self.ndocs)
+        while self.transform_count <= self.ndocs and not self.timeout_event.is_set():
             print("Inside transform loop.")
             with self.transform_batch_lock:
                 batch = self._get_transform_batch()

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -411,6 +411,8 @@ class PullTransformPush:
             with self.general_lock:
                 self.transform_bar.update(len(batch))
                 self.transform_count += len(batch)
+            if HAS_KILL_SIGNAL:
+                sys.exit()
 
     def _handle_failed_documents(
         self,

--- a/relevanceai/operations_new/ops_run.py
+++ b/relevanceai/operations_new/ops_run.py
@@ -285,6 +285,7 @@ class PullTransformPush:
             if not documents:
                 with self.general_lock:
                     self.ndocs = self.pull_count
+                print("Killing transform queue.")
                 self.tq.put(KILL_SIGNAL)
                 break
             after_id = res["after_id"]
@@ -366,7 +367,9 @@ class PullTransformPush:
         """
         # Check for early termination (such as no documents)
         HAS_KILL_SIGNAL: bool = False
+        print("Begin transform.")
         while self.transform_count < self.ndocs and not self.timeout_event.is_set():
+            print("Inside transform loop.")
             with self.transform_batch_lock:
                 batch = self._get_transform_batch()
                 if len(batch) > 0:


### PR DESCRIPTION
This PR exits the threads to avoid continuing to poll. This ensures that the execution does not hang. 