### PR TITLE
Fix validation errors in `view_task_steps()`, tool methods, and type coercion

### DIFF
--- a/relevanceai/resources/agent.py
+++ b/relevanceai/resources/agent.py
@@ -232,9 +232,19 @@ class Agent(SyncAPIResource):
         response = self._post(path, body=body)
         return response.json()
 
-    def add_tool(self, tool_id: str, partial_update: Optional[bool] = True) -> None:
+    def add_tool(
+        self,
+        tool_id: str,
+        action_behaviour: str = "always-ask",
+        partial_update: Optional[bool] = True,
+    ) -> None:
         path = "agents/upsert"
-        self.metadata.actions.append({"chain_id": tool_id})
+        if self.metadata.actions is None:
+            self.metadata.actions = []
+        self.metadata.actions.append({
+            "chain_id": tool_id,
+            "action_behaviour": action_behaviour,
+        })
         body = {
             "agent_id": self.agent_id,
             "actions": self.metadata.actions,
@@ -245,6 +255,8 @@ class Agent(SyncAPIResource):
 
     def remove_tool(self, tool_id: str, partial_update: Optional[bool] = True) -> None:
         path = "agents/upsert"
+        if self.metadata.actions is None:
+            self.metadata.actions = []
         self.metadata.actions = [
             action for action in self.metadata.actions if action["chain_id"] != tool_id
         ]

--- a/relevanceai/resources/tool.py
+++ b/relevanceai/resources/tool.py
@@ -96,12 +96,13 @@ class Tool(SyncAPIResource):
 
         for field_name, param in params.items():
             param_dict = param.model_dump(exclude_none=True)
+            param_dict.pop("required", None)
             params_schema["properties"][field_name] = param_dict
             if param.required:
                 params_schema["required"].append(field_name)
 
         state_mapping = {
-            field_name: f"params.{field_name}" 
+            field_name: f"params.{field_name}"
             for field_name in params.keys()
         }
 
@@ -115,17 +116,19 @@ class Tool(SyncAPIResource):
             }],
             "partial_update": True
         }
-        
+
         response = self._post(path, body=body)
         return response.json()
-        
+
     def update_transformations(
         self,
         transformations: List[TransformationBase],
     ) -> dict:
-        
+
         response = self._get(f"studios/{self.tool_id}/get")
-        current_state = response.json()["studio"].get("state_mapping", {})
+        current_studio = response.json()["studio"]
+        current_state = current_studio.get("state_mapping", {})
+        current_params_schema = current_studio.get("params_schema", {})
 
         state_mapping = {
             **current_state, 
@@ -147,14 +150,15 @@ class Tool(SyncAPIResource):
             "updates": [{
                 "studio_id": self.tool_id,
                 "transformations": transformation_config,
-                "state_mapping": state_mapping
+                "state_mapping": state_mapping,
+                "params_schema": current_params_schema,
             }],
             "partial_update": True
         }
-        
+
         response = self._post(path, body=body)
         return response.json()
-    
+
     def update_outputs(
         self, 
         last_step: bool = True,
@@ -278,12 +282,13 @@ class AsyncTool(AsyncAPIResource):
 
         for field_name, param in params.items():
             param_dict = param.model_dump(exclude_none=True)
+            param_dict.pop("required", None)
             params_schema["properties"][field_name] = param_dict
             if param.required:
                 params_schema["required"].append(field_name)
 
         state_mapping = {
-            field_name: f"params.{field_name}" 
+            field_name: f"params.{field_name}"
             for field_name in params.keys()
         }
 
@@ -297,16 +302,18 @@ class AsyncTool(AsyncAPIResource):
             }],
             "partial_update": True
         }
-        
+
         response = await self._post(path, body=body)
         return response.json()
-        
+
     async def update_transformations(
         self,
         transformations: List[TransformationBase],
     ) -> dict:
         response = await self._get(f"studios/{self.tool_id}/get")
-        current_state = response.json()["studio"].get("state_mapping", {})
+        current_studio = response.json()["studio"]
+        current_state = current_studio.get("state_mapping", {})
+        current_params_schema = current_studio.get("params_schema", {})
 
         state_mapping = {
             **current_state, 
@@ -328,14 +335,15 @@ class AsyncTool(AsyncAPIResource):
             "updates": [{
                 "studio_id": self.tool_id,
                 "transformations": transformation_config,
-                "state_mapping": state_mapping
+                "state_mapping": state_mapping,
+                "params_schema": current_params_schema,
             }],
             "partial_update": True
         }
-        
+
         response = await self._post(path, body=body)
         return response.json()
-    
+
     async def update_outputs(
         self, 
         last_step: bool = True,

--- a/relevanceai/resources/tools.py
+++ b/relevanceai/resources/tools.py
@@ -49,7 +49,7 @@ class ToolsManager(SyncAPIResource):
         output_schema = None,
         transformations = None
     ) -> Tool:
-        tool_id = uuid.uuid4()
+        tool_id = str(uuid.uuid4())
         path = "studios/bulk_update"
         body = {
             "updates": [

--- a/relevanceai/types/task.py
+++ b/relevanceai/types/task.py
@@ -2568,19 +2568,19 @@ class Content2(BaseModel):
     type: Literal['tool-run']
     thoughts: Optional[str] = None
     generating: Optional[bool] = None
-    tool_run_state: ToolRunState
-    tool_config: ToolConfig
-    action_details: ActionDetails
+    tool_run_state: Optional[ToolRunState] = None
+    tool_config: Optional[ToolConfig] = None
+    action_details: Optional[ActionDetails] = None
     display: Optional[Display1] = None
-    requires_confirmation: bool
+    requires_confirmation: Union[bool, str] = False
     confirmation: Optional[Confirmation] = None
-    params: Union[Params, Params1]
+    params: Optional[Union[Params, Params1]] = None
     errors: Optional[List[Error]] = None
     output: Optional[Dict[str, Any]] = None
     output_source: Optional[OutputSource] = None
     optimistic_output: Optional[Dict[str, Any]] = None
     component: Optional[Union[Component, Component1]] = None
-    original_message_ids: OriginalMessageIds2
+    original_message_ids: Optional[OriginalMessageIds2] = None
 
 
 class OriginalMessageIds3(BaseModel):

--- a/relevanceai/types/transformations.py
+++ b/relevanceai/types/transformations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, model_validator
 
 
 class TransformationBase(BaseModel):
@@ -30,6 +30,14 @@ class PythonCodeTransformation(TransformationBase):
             "code": "\nreturn \"Hello World!\""
         }
     )
+
+    @model_validator(mode='before')
+    @classmethod
+    def coerce_packages_to_list(cls, data: Any) -> Any:
+        params = data.get('params') if isinstance(data, dict) else None
+        if params and isinstance(params.get('packages'), str):
+            params['packages'] = [p.strip() for p in params['packages'].split(',')]
+        return data
 
 class SerperGoogleSearchTransformation(TransformationBase):
     transformation: str = "serper_google_search"

--- a/tests/resources/test_agent.py
+++ b/tests/resources/test_agent.py
@@ -266,13 +266,14 @@ class TestAgent:
             "agents/upsert",
             body={
                 "agent_id": "test-agent",
-                "actions": [{"chain_id": "tool-123"}],
+                "actions": [{"chain_id": "tool-123", "action_behaviour": "always-ask"}],
                 "partial_update": True,
             }
         )
-        
+
         assert len(agent.metadata.actions) == 1
         assert agent.metadata.actions[0]["chain_id"] == "tool-123"
+        assert agent.metadata.actions[0]["action_behaviour"] == "always-ask"
         assert result == {"status": "success"}
 
     def test_remove_tool(self, agent):


### PR DESCRIPTION
Fixes #1093 and #1094.

## Summary

Seven bugs across type models and resource methods that cause crashes or produce invalid data.

## Changes

### Type validation (#1093)

- **`Content2` model** (`types/task.py`): `requires_confirmation` changed from `bool` to `Union[bool, str]`; `tool_run_state`, `tool_config`, `action_details`, `params`, `original_message_ids` made `Optional` — fixes `view_task_steps()` `ValidationError` on tool-run responses
- **`update_params()`** (`resources/tool.py`): strip `required` from property dicts before adding to `params_schema["properties"]` — JSON Schema requires `required` as a top-level array, not a boolean inside properties
- **`PythonCodeTransformation`** (`types/transformations.py`): add `model_validator` to coerce `packages` string to list — platform API rejects strings with `must be array` validation error

### Resource methods (#1094)

- **`create_tool()`** (`resources/tools.py:52`): `uuid.uuid4()` → `str(uuid.uuid4())` — fixes `TypeError: Object of type UUID is not JSON serializable` (async version already correct)
- **`add_tool()`** (`resources/agent.py`): guard against `None` actions on fresh agents, expose `action_behaviour` parameter (`"always-ask"` | `"never-ask"` | `"agent-decide"`)
- **`remove_tool()`** (`resources/agent.py`): guard against `None` actions
- **`update_transformations()`** (`resources/tool.py`): fetch and include current `params_schema` in `bulk_update` body — prevents silent schema erasure when updating transformations after params

## Testing

- All 46 existing unit tests pass
- 18/18 end-to-end tests against live API (Content2 parsing, UUID serialization, null-safe add/remove_tool, action_behaviour, params schema validity, schema preservation, packages coercion, view_task_steps with tool-run responses)